### PR TITLE
Removes extra space at the top of the view

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,7 +48,7 @@
 /* Content */
 
 .github #tm_webpreview_content {
-  margin-top: 3em;
+  margin-top: 0;
   padding: 30px;
 }
 


### PR DESCRIPTION
I don't know if this is the intended behaviour, but in Textmate 2 I got this extra white space that I always remove from the `style.css` file in the theme.

<img width="692" alt="screen shot 2018-01-23 at 21 46 11" src="https://user-images.githubusercontent.com/6335/35299908-2404a782-0087-11e8-86d7-4c4b9f91a090.png">

<img width="685" alt="screen shot 2018-01-23 at 21 47 45" src="https://user-images.githubusercontent.com/6335/35299914-27859fb0-0087-11e8-91a6-cd0f07a2df84.png">
